### PR TITLE
Annotate `string` to type to resolved value from `Priomise`

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -74,7 +74,7 @@ describe('index', () => {
     process.env['INPUT_TRANSFER_OWNERSHIP'] = 'false'
     process.env['INPUT_SEND_NOTIFICATION_EMAIL'] = 'true'
     process.env['INPUT_EMAIL_MESSAGE'] = ''
-    const [stdout, stderr] = await new Promise((resolve) => {
+    const [stdout, stderr]: [string, string] = await new Promise((resolve) => {
       cp.exec(`node ${ip}`, { env: process.env }, (_err, stdout, stderr) => {
         resolve([stdout.toString(), stderr.toString()])
       })
@@ -97,7 +97,7 @@ describe('index', () => {
     process.env['INPUT_TRANSFER_OWNERSHIP'] = 'false'
     process.env['INPUT_SEND_NOTIFICATION_EMAIL'] = 'true'
     process.env['INPUT_EMAIL_MESSAGE'] = ''
-    const [stdout, stderr] = await new Promise((resolve) => {
+    const [stdout, stderr]: [string, string] = await new Promise((resolve) => {
       cp.exec(`node ${ip}`, { env: process.env }, (_err, stdout, stderr) => {
         resolve([stdout.toString(), stderr.toString()])
       })


### PR DESCRIPTION
It avoid following error in TypeScript 4.8.2.

Error: [tsl] ERROR in /workspaces/gdrive-act-recv/test/index.spec.ts(41,11)
TS2488: Type 'unknown' must have a '[Symbol.iterator]()' method that returns an iterator.
